### PR TITLE
Clarified part of the Statements and Control Flow

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_basics.rst
+++ b/getting_started/scripting/gdscript/gdscript_basics.rst
@@ -763,8 +763,7 @@ Statements and control flow
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Statements are standard and can be assignments, function calls, control
-flow structures, etc (see below). ``;`` as a statement separator is
-entirely optional.
+flow structures, etc (see below). ``:`` as a statement separator required.
 
 if/else/elif
 ^^^^^^^^^^^^


### PR DESCRIPTION
The description said that a semicolon separator was "entirely optional." The code below used colons. I checked with a more knowledgeable person and they said that the semicolon shouldn't be used in the place of the colon and that the colon was required. I made changes to the wording to reflect this in the GDScript Basics documentation.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
